### PR TITLE
docs(instructions): update code to be compatible with node

### DIFF
--- a/instructions/0-redux.md
+++ b/instructions/0-redux.md
@@ -15,7 +15,7 @@ To operate Redux uses a concept of `reducer` which works exactly the same way th
 let's take a simple example :
 
 ```javascript
-import { createStore } from 'redux'
+const {createStore} = require('redux');
 
 /**
  * Here we have a unique reducer to handle a state of type `number`


### PR DESCRIPTION
Since nodejs doesn't support the ES6 notation, the command `node tryoutredux.js` was running an exception :
<img width="686" alt="screen shot 2017-10-06 at 17 01 11" src="https://user-images.githubusercontent.com/3619889/31284147-0a81cfee-aab8-11e7-8035-ee9c4cdca8f6.png">